### PR TITLE
Fix a serious bug with the --is_handcrafted argument

### DIFF
--- a/Automated_FA/inference.py
+++ b/Automated_FA/inference.py
@@ -174,6 +174,7 @@ def main():
     handcrafted_suffix = "_handcrafted" if args.is_handcrafted == "True" else "_alg_generated"
     output_filename = f"{args.method}_{args.model.replace('/','_')}{handcrafted_suffix}.txt"
     output_filepath = os.path.join(output_dir, output_filename)
+    args.is_handcrafted = True if args.is_handcrafted == "True" else False
 
     print(f"Analysis method: {args.method}")
     print(f"Model Alias: {args.model} (Family: {model_family})")


### PR DESCRIPTION
all_at_once, step_by_step, and binary_search expect is_handcrafted to be a boolean variable, but the current code is feeding in a non-empty string which is always evaluated as True. This is probably why the Agent-Level Accuracy is so low.